### PR TITLE
Replace Http facade usage with GuzzleHTTP client for Laravel versions…

### DIFF
--- a/src/SMS.php
+++ b/src/SMS.php
@@ -2,7 +2,8 @@
 
 namespace sms_net_bd;
 
-use Illuminate\Support\Facades\Http;
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
 
 class SMS
 {
@@ -106,14 +107,23 @@ class SMS
     }
 
     private function makeRequest($method, $url, $params)
-    {
+    { 
+        $client = new Client();
+        
+        $options = [
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+        ];
+        
         if ($method === 'GET') {
-            $response = Http::acceptJson()->get($url, $params);
+            $response = $client->get($url, $options);
         } else {
-            $response = Http::asForm()->acceptJson()->post($url, $params);
+            $options[RequestOptions::FORM_PARAMS] = $params;
+            $response = $client->post($url, $options);
         }
-
-        return $response->json();
+        
+        return json_decode($response->getBody(), true);
     }
 
     private function handleResponse($response)


### PR DESCRIPTION
This pull request replaces the usage of the Http facade with direct usage of the GuzzleHTTP client in Laravel versions prior to 7.x.

In Laravel versions prior to 7.x, the Http facade is not available, and developers typically utilize GuzzleHTTP client directly for making HTTP requests. This pull request ensures compatibility with older Laravel versions by replacing the Http facade usage with the GuzzleHTTP client.